### PR TITLE
Change the omnibox keyword to "ph"

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,7 +27,7 @@
     "default_popup": "apps/popup/main.html"
   },
   "omnibox": {
-    "keyword": "product"
+    "keyword": "ph"
   },
   "permissions": [
     "*://www.producthunt.com/*",


### PR DESCRIPTION
## Scope

The current omnibox keyword, which is "product", is too commonly used, therefore we are changing it to something more friendly. It's a "breaking" change but better long term solution.

Suggestions to better keywords appreciated and will be considered!